### PR TITLE
fix(payment): correct penalty calculation for past-date payments

### DIFF
--- a/docs/translations.md
+++ b/docs/translations.md
@@ -1,0 +1,80 @@
+### Translation Management
+
+This app uses CSV-based translations instead of the Translation DocType fixtures. This approach is simpler and more maintainable.
+
+## File Location
+
+Place translation CSV files in:
+```
+[app_name]/[app_name]/translations/[lang].csv
+```
+
+Example for factory_miscel Spanish:
+```
+factory_miscel/factory_miscel/translations/es.csv
+```
+
+## Adding Translations
+
+1. Create `translations/[lang].csv` (e.g., `es.csv` for Spanish)
+2. Add translations in CSV format
+3. Rebuild the app: `bench build --app factory_miscel`
+4. Clear cache: `bench clear-cache`
+
+## CSV Format
+
+```csv
+"Source String","Translated String"
+"Button Text","Texto del Boton"
+"Error: {0}","Error: {0}"
+```
+
+**Rules:**
+- One translation per line
+- Source and translation separated by comma
+- Strings with special chars must be quoted
+- Use `{0}`, `{1}` for placeholders
+
+## Example: es.csv
+
+```csv
+"Submit with Adjustment","Enviar con Ajuste"
+"Actions","Acciones"
+"Checking batch quantities...","Verificando cantidades de lotes..."
+"Error checking batch quantities: {0}","Error al verificar cantidades de lotes: {0}"
+"Batch Quantity Adjustment Required","Se Requiere Ajuste de Cantidad de Lote"
+"The following batches have insufficient quantities:","Los siguientes lotes tienen cantidades insuficientes:"
+"Batch","Lote"
+"Item","Articulo"
+"Warehouse","Almacen"
+"Required","Requerido"
+"Available","Disponible"
+"Adjustment","Ajuste"
+"Create stock adjustments for missing quantities and submit?","Crear ajustes de inventario para cantidades faltantes y enviar?"
+"Submission cancelled","Envio cancelado"
+"Creating adjustments and submitting...","Creando ajustes y enviando..."
+"Stock Entry submitted successfully!","Entrada de Stock enviada exitosamente!"
+"Created {0} stock adjustment(s):","{0} ajuste(s) de inventario creado(s):"
+"Stock Entry submitted successfully","Entrada de Stock enviada exitosamente"
+"Error submitting stock entry: {0}","Error al enviar entrada de stock: {0}"
+"Unknown error","Error desconocido"
+"Submitting...","Enviando..."
+```
+
+## Why CSV Over Fixtures?
+
+| Fixtures/Translation DocType | CSV Approach |
+|------------------------------|--------------|
+| Create documents in UI | Edit directly in code |
+| Export via command | Already in version control |
+| Harder to review changes | Easy to diff in git |
+| Requires import on new sites | Travels with app code |
+| More steps for updates | Just edit and rebuild |
+
+## Supported Languages
+
+Add a new file for each language:
+- `translations/es.csv` - Spanish
+- `translations/fr.csv` - French
+- `translations/de.csv` - German
+- etc.

--- a/financed_sales/financed_sales/api.py
+++ b/financed_sales/financed_sales/api.py
@@ -1,4 +1,6 @@
 import json
+import math
+from datetime import date
 from types import SimpleNamespace
 
 import frappe
@@ -7,6 +9,100 @@ from frappe import _
 
 from .allocation_wrapper import analyze_payment_allocation
 from .penalty_journal import create_penalty_journal_entry
+
+
+def calculate_penalty_for_date(due_date, installment_amount, paid_amount, reference_date):
+	"""
+	Calculate penalty for an installment based on a specific date.
+	
+	Args:
+		due_date: The due date of the installment
+		installment_amount: The original installment amount
+		paid_amount: Amount already paid toward the installment
+		reference_date: The date to calculate penalty for (typically payment date)
+	
+	Returns:
+		float: Calculated penalty amount (0 if not overdue or in grace period)
+	"""
+	if not due_date:
+		return 0
+	
+	ref_date = reference_date if isinstance(reference_date, date) else frappe.utils.getdate(reference_date)
+	due = due_date if isinstance(due_date, date) else frappe.utils.getdate(due_date)
+	
+	if due >= ref_date:
+		return 0  # Not overdue
+	
+	days_overdue = (ref_date - due).days
+	
+	if days_overdue <= 5:
+		return 0  # Grace period
+	
+	# Calculate 30-day periods overdue after grace period
+	days_after_grace = days_overdue - 5
+	periods_overdue = math.ceil(days_after_grace / 30.0)
+	penalty_rate = periods_overdue * 0.05  # 5% per 30-day period
+	
+	# Calculate penalty on unpaid installment amount
+	unpaid_installment = installment_amount - paid_amount
+	return round(unpaid_installment * penalty_rate, 2)
+
+
+def recalculate_installment_penalties_for_date(payment_plan_doc, reference_date):
+	"""
+	Recalculate penalty amounts for overdue installments in a payment plan based on a specific date.
+	Only updates installments that ARE overdue on the reference date.
+	For installments not yet due, preserves existing penalty amounts.
+	
+	Args:
+		payment_plan_doc: Payment Plan document
+		reference_date: The date to calculate penalties for
+	
+	Returns:
+		list: Names of installments that were updated
+	"""
+	from datetime import date as date_type
+	
+	updated_installments = []
+	ref_date = reference_date if isinstance(reference_date, (date, str)) else frappe.utils.getdate(reference_date)
+	if isinstance(ref_date, str):
+		ref_date = frappe.utils.getdate(ref_date)
+	
+	for installment in payment_plan_doc.installments:
+		# Skip fully paid installments
+		if installment.paid_amount >= installment.amount:
+			continue
+		
+		# Only recalculate for installments that ARE overdue on the reference date
+		due_date = installment.due_date
+		if isinstance(due_date, str):
+			due_date = frappe.utils.getdate(due_date)
+		
+		# If not overdue on reference date, preserve existing penalty
+		if not due_date or due_date >= ref_date:
+			continue
+		
+		new_penalty = calculate_penalty_for_date(
+			installment.due_date,
+			installment.amount,
+			installment.paid_amount,
+			reference_date
+		)
+		
+		if installment.penalty_amount != new_penalty:
+			# Update the penalty amount in the database
+			frappe.db.set_value(
+				"Payment Plan Installment",
+				installment.name,
+				"penalty_amount",
+				new_penalty
+			)
+			updated_installments.append(installment.name)
+	
+	if updated_installments:
+		frappe.db.commit()
+	
+	return updated_installments
 
 
 def validate_payment_date(payment_plan_name, posting_date):
@@ -137,6 +233,14 @@ def create_payment_entry_from_payment_plan(
 	# Get payment plan document for allocation analysis
 	payment_plan = frappe.get_doc("Payment Plan", payment_plan_name)
 
+	# Recalculate penalties based on payment date (not today)
+	# This ensures penalty reflects the date being recorded
+	reference_date = posting_date if posting_date else frappe.utils.today()
+	recalculate_installment_penalties_for_date(payment_plan, reference_date)
+	
+	# Reload payment plan to get updated penalty amounts
+	payment_plan.reload()
+
 	# Use allocation analysis to determine if penalty payment is needed
 	allocation_result = analyze_payment_allocation(payment_plan, paid_amount)
 
@@ -148,6 +252,7 @@ def create_payment_entry_from_payment_plan(
 			penalty_amount=allocation_result["penalty_amount"],
 			customer=payment_plan.customer,
 			payment_plan_name=payment_plan_name,
+			posting_date=posting_date,
 		)
 
 	# Create payment entry with appropriate references

--- a/financed_sales/financed_sales/api.py
+++ b/financed_sales/financed_sales/api.py
@@ -9,6 +9,24 @@ from .allocation_wrapper import analyze_payment_allocation
 from .penalty_journal import create_penalty_journal_entry
 
 
+def validate_payment_date(payment_plan_name, posting_date):
+	if not posting_date:
+		return
+	result = frappe.db.sql(
+		"SELECT MAX(date) as max_date FROM `tabFinanced Payment Ref` WHERE parent = %s",
+		payment_plan_name,
+	)
+	last_date = result[0][0] if result and result[0] else None
+	if last_date:
+		if isinstance(posting_date, str):
+			posting_date = frappe.utils.getdate(posting_date)
+		if posting_date < last_date:
+			frappe.throw(
+				_(f"Payment date cannot be before {frappe.format(last_date, 'Date')}. "
+				  "Payments must be recorded in chronological order.")
+			)
+
+
 @frappe.whitelist()
 def create_finance_app_from_pos_cart(customer, items):
 	"""
@@ -102,7 +120,7 @@ def create_down_payment_from_fin_app(fin_app_name):
 
 @frappe.whitelist()
 def create_payment_entry_from_payment_plan(
-	payment_plan_name, paid_amount, mode_of_payment, submit=False, reference_number=None, reference_date=None
+	payment_plan_name, paid_amount, mode_of_payment, submit=False, reference_number=None, reference_date=None, posting_date=None
 ):
 	# Validate required parameters
 	if not mode_of_payment:
@@ -111,6 +129,10 @@ def create_payment_entry_from_payment_plan(
 		frappe.throw(_("Payment amount is required. Please enter the amount to pay."))
 
 	paid_amount = float(paid_amount)
+
+	# Validate payment date is not before last payment
+	if posting_date:
+		validate_payment_date(payment_plan_name, posting_date)
 
 	# Get payment plan document for allocation analysis
 	payment_plan = frappe.get_doc("Payment Plan", payment_plan_name)
@@ -141,6 +163,7 @@ def create_payment_entry_from_payment_plan(
 		reference_date,
 		journal_entry_name,
 		allocation_result["penalty_amount"],
+		posting_date,
 	)
 
 
@@ -174,6 +197,7 @@ def create_payment_entry(
 	reference_date=None,
 	journal_entry_reference=None,
 	penalty_amount=0,
+	posting_date=None,
 ):
 	pe = get_payment_entry(doc.doctype, doc.name, party_amount=paid_amount)
 	pe.mode_of_payment = mode_of_payment
@@ -192,6 +216,9 @@ def create_payment_entry(
 
 	pe.paid_to = account
 	pe.custom_is_finance_payment = 1
+
+	if posting_date:
+		pe.posting_date = posting_date
 
 	# Set reference number and date for Bank type payments
 	mode_of_payment_type = frappe.db.get_value("Mode of Payment", mode_of_payment, "type")

--- a/financed_sales/financed_sales/api.py
+++ b/financed_sales/financed_sales/api.py
@@ -1,6 +1,4 @@
 import json
-import math
-from datetime import date
 from types import SimpleNamespace
 
 import frappe
@@ -9,100 +7,6 @@ from frappe import _
 
 from .allocation_wrapper import analyze_payment_allocation
 from .penalty_journal import create_penalty_journal_entry
-
-
-def calculate_penalty_for_date(due_date, installment_amount, paid_amount, reference_date):
-	"""
-	Calculate penalty for an installment based on a specific date.
-	
-	Args:
-		due_date: The due date of the installment
-		installment_amount: The original installment amount
-		paid_amount: Amount already paid toward the installment
-		reference_date: The date to calculate penalty for (typically payment date)
-	
-	Returns:
-		float: Calculated penalty amount (0 if not overdue or in grace period)
-	"""
-	if not due_date:
-		return 0
-	
-	ref_date = reference_date if isinstance(reference_date, date) else frappe.utils.getdate(reference_date)
-	due = due_date if isinstance(due_date, date) else frappe.utils.getdate(due_date)
-	
-	if due >= ref_date:
-		return 0  # Not overdue
-	
-	days_overdue = (ref_date - due).days
-	
-	if days_overdue <= 5:
-		return 0  # Grace period
-	
-	# Calculate 30-day periods overdue after grace period
-	days_after_grace = days_overdue - 5
-	periods_overdue = math.ceil(days_after_grace / 30.0)
-	penalty_rate = periods_overdue * 0.05  # 5% per 30-day period
-	
-	# Calculate penalty on unpaid installment amount
-	unpaid_installment = installment_amount - paid_amount
-	return round(unpaid_installment * penalty_rate, 2)
-
-
-def recalculate_installment_penalties_for_date(payment_plan_doc, reference_date):
-	"""
-	Recalculate penalty amounts for overdue installments in a payment plan based on a specific date.
-	Only updates installments that ARE overdue on the reference date.
-	For installments not yet due, preserves existing penalty amounts.
-	
-	Args:
-		payment_plan_doc: Payment Plan document
-		reference_date: The date to calculate penalties for
-	
-	Returns:
-		list: Names of installments that were updated
-	"""
-	from datetime import date as date_type
-	
-	updated_installments = []
-	ref_date = reference_date if isinstance(reference_date, (date, str)) else frappe.utils.getdate(reference_date)
-	if isinstance(ref_date, str):
-		ref_date = frappe.utils.getdate(ref_date)
-	
-	for installment in payment_plan_doc.installments:
-		# Skip fully paid installments
-		if installment.paid_amount >= installment.amount:
-			continue
-		
-		# Only recalculate for installments that ARE overdue on the reference date
-		due_date = installment.due_date
-		if isinstance(due_date, str):
-			due_date = frappe.utils.getdate(due_date)
-		
-		# If not overdue on reference date, preserve existing penalty
-		if not due_date or due_date >= ref_date:
-			continue
-		
-		new_penalty = calculate_penalty_for_date(
-			installment.due_date,
-			installment.amount,
-			installment.paid_amount,
-			reference_date
-		)
-		
-		if installment.penalty_amount != new_penalty:
-			# Update the penalty amount in the database
-			frappe.db.set_value(
-				"Payment Plan Installment",
-				installment.name,
-				"penalty_amount",
-				new_penalty
-			)
-			updated_installments.append(installment.name)
-	
-	if updated_installments:
-		frappe.db.commit()
-	
-	return updated_installments
 
 
 def validate_payment_date(payment_plan_name, posting_date):
@@ -233,10 +137,10 @@ def create_payment_entry_from_payment_plan(
 	# Get payment plan document for allocation analysis
 	payment_plan = frappe.get_doc("Payment Plan", payment_plan_name)
 
-	# Recalculate penalties based on payment date (not today)
+	# Recalculate penalties based on payment date
 	# This ensures penalty reflects the date being recorded
-	reference_date = posting_date if posting_date else frappe.utils.today()
-	recalculate_installment_penalties_for_date(payment_plan, reference_date)
+	calc_date = posting_date if posting_date else frappe.utils.today()
+	payment_plan.calculate_overdue_penalties(calc_date)
 	
 	# Reload payment plan to get updated penalty amounts
 	payment_plan.reload()
@@ -259,7 +163,7 @@ def create_payment_entry_from_payment_plan(
 	si_name = frappe.db.get_value("Payment Plan", payment_plan_name, "credit_invoice")
 	si = SimpleNamespace(doctype="Sales Invoice", name=si_name)
 
-	return create_payment_entry(
+	pe_name = create_payment_entry(
 		si,
 		paid_amount,
 		mode_of_payment,
@@ -270,6 +174,11 @@ def create_payment_entry_from_payment_plan(
 		allocation_result["penalty_amount"],
 		posting_date,
 	)
+
+	# Resync penalties to today after payment
+	payment_plan.calculate_overdue_penalties()
+
+	return pe_name
 
 
 @frappe.whitelist()

--- a/financed_sales/financed_sales/api.py
+++ b/financed_sales/financed_sales/api.py
@@ -141,9 +141,6 @@ def create_payment_entry_from_payment_plan(
 	# This ensures penalty reflects the date being recorded
 	calc_date = posting_date if posting_date else frappe.utils.today()
 	payment_plan.calculate_overdue_penalties(calc_date)
-	
-	# Reload payment plan to get updated penalty amounts
-	payment_plan.reload()
 
 	# Use allocation analysis to determine if penalty payment is needed
 	allocation_result = analyze_payment_allocation(payment_plan, paid_amount)
@@ -176,6 +173,8 @@ def create_payment_entry_from_payment_plan(
 	)
 
 	# Resync penalties to today after payment
+	# Reload to get updated paid_amount from update_payments() hook
+	payment_plan.reload()
 	payment_plan.calculate_overdue_penalties()
 
 	return pe_name

--- a/financed_sales/financed_sales/doctype/payment_plan/payment_plan.js
+++ b/financed_sales/financed_sales/doctype/payment_plan/payment_plan.js
@@ -101,6 +101,23 @@ return new frappe.ui.Dialog({
 				default: frappe.datetime.get_today(),
 				hidden: 1,
 			},
+			{
+				label: 'Set custom date',
+				fieldname: 'set_custom_date',
+				fieldtype: 'Check',
+				default: 0,
+				onchange: function() {
+					const dialog = window.cur_dialog;
+					dialog.set_df_property('posting_date', 'read_only', !this.get_value());
+				}
+			},
+			{
+				label: 'Payment date',
+				fieldname: 'posting_date',
+				fieldtype: 'Date',
+				default: frappe.datetime.get_today(),
+				read_only: 1,
+			},
 	],
 	size: 'small', // small, large, extra-large 
 	primary_action_label: 'Submit payment',
@@ -169,6 +186,7 @@ function submit_payment(payment_values, source_name, source_type) {
 		args.finance_application_name = source_name;
 	} else {
 		args.payment_plan_name = source_name;
+		args.posting_date = payment_values.posting_date;
 	}
 	
 	// Check payment method type to determine if reference fields are needed

--- a/financed_sales/financed_sales/doctype/payment_plan/payment_plan.py
+++ b/financed_sales/financed_sales/doctype/payment_plan/payment_plan.py
@@ -75,7 +75,7 @@ class PaymentPlan(Document):
 			frappe.log_error(f"Failed to update Payment Plan {self.name} status: {str(e)}")
 			# Don't raise exception to avoid breaking payment processing
 	
-	def calculate_overdue_penalties(self):
+	def calculate_overdue_penalties(self, calc_date=None):
 		"""Calculate progressive penalties for overdue installments using 30-day periods.
 		
 		Penalty structure:
@@ -88,6 +88,9 @@ class PaymentPlan(Document):
 		Uses fixed 30-day periods as requested by client.
 		Formula: penalty_amount = installment_amount × periods_overdue × 5%
 		
+		Args:
+			calc_date: Date to calculate penalties for. Can be date object or string (YYYY-MM-DD). Defaults to today.
+		
 		Returns:
 			int: Number of installments that had penalties updated.
 		"""
@@ -96,17 +99,21 @@ class PaymentPlan(Document):
 		if not self.installments:
 			return 0
 		
-		today = date.today()
+		if calc_date is None:
+			calc_date = date.today()
+		elif isinstance(calc_date, str):
+			calc_date = frappe.utils.getdate(calc_date)
+		
 		updated_count = 0
 		
 		for installment in self.installments:
 			# Check if installment is overdue and has pending amount
 			if (installment.due_date and 
-				installment.due_date < today and 
+				installment.due_date < calc_date and 
 				installment.pending_amount > 0):
 				
 				# Calculate days overdue
-				days_overdue = (today - installment.due_date).days
+				days_overdue = (calc_date - installment.due_date).days
 				
 				# Calculate penalty based on 30-day periods with grace period
 				if days_overdue <= 5:

--- a/financed_sales/financed_sales/doctype/payment_plan/payment_plan.py
+++ b/financed_sales/financed_sales/doctype/payment_plan/payment_plan.py
@@ -140,6 +140,9 @@ class PaymentPlan(Document):
 						"penalty_amount": new_penalty,
 						"pending_amount": expected_pending_amount
 					})
+					# Also update in-memory object so reload() isn't needed
+					installment.penalty_amount = new_penalty
+					installment.pending_amount = expected_pending_amount
 					updated_count += 1
 		
 		if updated_count > 0:

--- a/financed_sales/financed_sales/penalty_journal.py
+++ b/financed_sales/financed_sales/penalty_journal.py
@@ -5,7 +5,7 @@ import frappe
 from erpnext.accounts.party import get_party_account
 
 
-def create_penalty_journal_entry(penalty_amount, customer, payment_plan_name):
+def create_penalty_journal_entry(penalty_amount, customer, payment_plan_name, posting_date=None):
 	"""
 	Create Journal Entry document for penalty amounts with proper accounting entries.
 
@@ -17,6 +17,7 @@ def create_penalty_journal_entry(penalty_amount, customer, payment_plan_name):
 	    penalty_amount (float): Amount of penalty to be recorded
 	    customer (str): Customer name
 	    payment_plan_name (str): Payment Plan name for reference
+	    posting_date (str, optional): Date for the journal entry. Defaults to today.
 
 	Returns:
 	    str: Journal Entry name for referencing in payment entry
@@ -61,7 +62,7 @@ def create_penalty_journal_entry(penalty_amount, customer, payment_plan_name):
 	# Create Journal Entry
 	je = frappe.new_doc("Journal Entry")
 	je.voucher_type = "Journal Entry"
-	je.posting_date = frappe.utils.today()
+	je.posting_date = posting_date if posting_date else frappe.utils.today()
 	je.company = company
 	je.remark = f"Penalty entry for Payment Plan {payment_plan_name} - Customer: {customer}"
 

--- a/financed_sales/financed_sales/test_custom_payment_date.py
+++ b/financed_sales/financed_sales/test_custom_payment_date.py
@@ -104,38 +104,78 @@ class TestCustomPaymentDate(unittest.TestCase):
 		journal_entry = frappe.get_doc("Journal Entry", journal_entry_ref.reference_name)
 		self.assertEqual(str(journal_entry.posting_date), custom_date)
 
-	def test_payment_resyncs_penalties_to_today(self):
-		"""Test that penalties are recalculated to today after payment is created"""
+	def test_payment_with_past_date_uses_correct_penalty_calculation(self):
+		"""Test that payment with past date uses penalty calculated for that date,
+		and that penalties are resynced to today after payment."""
 		test_data = create_test_payment_plan_for_payment_entry()
 		payment_plan = frappe.get_doc("Payment Plan", test_data["payment_plan"])
 
-		second_installment = payment_plan.installments[1]
-		custom_date_str = frappe.utils.add_days(frappe.utils.today(), -20)
+		past_payment_date = frappe.utils.add_days(frappe.utils.today(), -20)
+
+		installment_1 = payment_plan.installments[0]
+		installment_2 = payment_plan.installments[1]
 
 		frappe.db.set_value(
 			"Payment Plan Installment",
-			second_installment.name,
-			{
-				"due_date": frappe.utils.add_days(custom_date_str, -50),
-				"penalty_amount": 250
-			}
+			installment_1.name,
+			{"due_date": frappe.utils.add_days(past_payment_date, -50)}
+		)
+		frappe.db.set_value(
+			"Payment Plan Installment",
+			installment_2.name,
+			{"due_date": frappe.utils.add_days(past_payment_date, -25)}
 		)
 
-		down_payment = payment_plan.down_payment_amount
-		first_installment_amount = payment_plan.installments[0].amount
-		second_installment_total = second_installment.amount + 250
+		installment_1_amount = installment_1.amount
+		installment_2_amount = installment_2.amount
+		down_payment_amount = payment_plan.down_payment_amount
 
-		total_payment = down_payment + first_installment_amount + second_installment_total
+		penalty_at_past_date_1 = round(installment_1_amount * 0.10, 2)
+		penalty_at_past_date_2 = round(installment_2_amount * 0.05, 2)
 
-		create_payment_entry_from_payment_plan(
+		payment_amount = down_payment_amount + installment_1_amount + penalty_at_past_date_1
+
+		payment_entry_name = create_payment_entry_from_payment_plan(
 			payment_plan_name=test_data["payment_plan"],
-			paid_amount=total_payment,
+			paid_amount=payment_amount,
 			mode_of_payment=test_data["mode_of_payment"],
 			submit=True,
-			posting_date=custom_date_str,
+			posting_date=past_payment_date,
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", payment_entry_name)
+		self.assertEqual(str(payment_entry.posting_date), past_payment_date)
+
+		journal_entry_ref = None
+		for ref in payment_entry.references:
+			if ref.reference_doctype == "Journal Entry":
+				journal_entry_ref = ref
+				break
+
+		self.assertIsNotNone(journal_entry_ref, "Should have Journal Entry reference")
+		journal_entry = frappe.get_doc("Journal Entry", journal_entry_ref.reference_name)
+		total_debit = sum(entry.debit_in_account_currency for entry in journal_entry.accounts)
+		self.assertEqual(
+			total_debit,
+			penalty_at_past_date_1,
+			f"JE should use penalty calculated at past date ({penalty_at_past_date_1}), not current penalty"
 		)
 
 		payment_plan.reload()
-		second_installment.reload()
+		installment_1.reload()
+		installment_2.reload()
 
-		self.assertGreaterEqual(second_installment.paid_amount, 0)
+		penalty_at_today_1 = round(installment_1_amount * 0.15, 2)
+		penalty_at_today_2 = round(installment_2_amount * 0.10, 2)
+
+		self.assertEqual(
+			installment_1.penalty_amount,
+			penalty_at_today_1,
+			"Installment 1 penalty should be resynced to today's calculation"
+		)
+
+		self.assertEqual(
+			installment_2.penalty_amount,
+			penalty_at_today_2,
+			"Installment 2 penalty should be resynced to today's calculation (not affected by payment but still resynced)"
+		)

--- a/financed_sales/financed_sales/test_custom_payment_date.py
+++ b/financed_sales/financed_sales/test_custom_payment_date.py
@@ -1,0 +1,141 @@
+import unittest
+
+import frappe
+
+from .api import create_payment_entry_from_payment_plan
+from .factories.payment_plan_factory import create_test_payment_plan_for_payment_entry
+
+
+class TestCustomPaymentDate(unittest.TestCase):
+	def test_payment_with_custom_date_sets_correct_posting_date(self):
+		"""Test that payment entry uses custom posting date when provided"""
+		test_data = create_test_payment_plan_for_payment_entry()
+		custom_date = "2026-01-15"
+
+		payment_entry_name = create_payment_entry_from_payment_plan(
+			payment_plan_name=test_data["payment_plan"],
+			paid_amount=1000,
+			mode_of_payment=test_data["mode_of_payment"],
+			submit=True,
+			posting_date=custom_date,
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", payment_entry_name)
+		self.assertEqual(str(payment_entry.posting_date), custom_date)
+
+	def test_payment_without_custom_date_uses_today(self):
+		"""Test that payment entry uses today's date when no custom date provided"""
+		test_data = create_test_payment_plan_for_payment_entry()
+
+		payment_entry_name = create_payment_entry_from_payment_plan(
+			payment_plan_name=test_data["payment_plan"],
+			paid_amount=1000,
+			mode_of_payment=test_data["mode_of_payment"],
+			submit=True,
+			posting_date=None,
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", payment_entry_name)
+		self.assertEqual(str(payment_entry.posting_date), frappe.utils.today())
+
+	def test_payment_date_before_last_payment_rejected(self):
+		"""Test that payment date before last payment is rejected"""
+		test_data = create_test_payment_plan_for_payment_entry()
+
+		create_payment_entry_from_payment_plan(
+			payment_plan_name=test_data["payment_plan"],
+			paid_amount=1000,
+			mode_of_payment=test_data["mode_of_payment"],
+			submit=True,
+			posting_date="2026-03-20",
+		)
+
+		with self.assertRaises(frappe.ValidationError) as context:
+			create_payment_entry_from_payment_plan(
+				payment_plan_name=test_data["payment_plan"],
+				paid_amount=500,
+				mode_of_payment=test_data["mode_of_payment"],
+				submit=True,
+				posting_date="2026-03-15",
+			)
+
+		self.assertIn("Payment date cannot be before", str(context.exception))
+
+	def test_payment_with_custom_date_creates_je_with_correct_date(self):
+		"""Test that Journal Entry is created with custom posting date when penalty exists"""
+		test_data = create_test_payment_plan_for_payment_entry()
+		payment_plan = frappe.get_doc("Payment Plan", test_data["payment_plan"])
+
+		custom_date = "2026-02-15"
+
+		second_installment = payment_plan.installments[1]
+		frappe.db.set_value(
+			"Payment Plan Installment",
+			second_installment.name,
+			{
+				"due_date": frappe.utils.add_days(custom_date, -40),
+			}
+		)
+
+		down_payment = payment_plan.down_payment_amount
+		first_installment_amount = payment_plan.installments[0].amount
+		second_installment_total = second_installment.amount + 500
+
+		total_payment = down_payment + first_installment_amount + second_installment_total
+
+		payment_entry_name = create_payment_entry_from_payment_plan(
+			payment_plan_name=test_data["payment_plan"],
+			paid_amount=total_payment,
+			mode_of_payment=test_data["mode_of_payment"],
+			submit=True,
+			posting_date=custom_date,
+		)
+
+		payment_entry = frappe.get_doc("Payment Entry", payment_entry_name)
+		self.assertEqual(str(payment_entry.posting_date), custom_date)
+
+		journal_entry_ref = None
+		for ref in payment_entry.references:
+			if ref.reference_doctype == "Journal Entry":
+				journal_entry_ref = ref
+				break
+
+		self.assertIsNotNone(journal_entry_ref, "Should have Journal Entry reference")
+		journal_entry = frappe.get_doc("Journal Entry", journal_entry_ref.reference_name)
+		self.assertEqual(str(journal_entry.posting_date), custom_date)
+
+	def test_payment_resyncs_penalties_to_today(self):
+		"""Test that penalties are recalculated to today after payment is created"""
+		test_data = create_test_payment_plan_for_payment_entry()
+		payment_plan = frappe.get_doc("Payment Plan", test_data["payment_plan"])
+
+		second_installment = payment_plan.installments[1]
+		custom_date_str = frappe.utils.add_days(frappe.utils.today(), -20)
+
+		frappe.db.set_value(
+			"Payment Plan Installment",
+			second_installment.name,
+			{
+				"due_date": frappe.utils.add_days(custom_date_str, -50),
+				"penalty_amount": 250
+			}
+		)
+
+		down_payment = payment_plan.down_payment_amount
+		first_installment_amount = payment_plan.installments[0].amount
+		second_installment_total = second_installment.amount + 250
+
+		total_payment = down_payment + first_installment_amount + second_installment_total
+
+		create_payment_entry_from_payment_plan(
+			payment_plan_name=test_data["payment_plan"],
+			paid_amount=total_payment,
+			mode_of_payment=test_data["mode_of_payment"],
+			submit=True,
+			posting_date=custom_date_str,
+		)
+
+		payment_plan.reload()
+		second_installment.reload()
+
+		self.assertGreaterEqual(second_installment.paid_amount, 0)

--- a/financed_sales/financed_sales/validate_payment_entry.py
+++ b/financed_sales/financed_sales/validate_payment_entry.py
@@ -1,0 +1,48 @@
+import frappe
+from frappe import _
+
+
+def validate_payment_entry_references(doc, method):
+    """
+    Prevent direct payment entries against financed Sales Invoices.
+    All payments for financed sales must go through the Finance Application workflow
+    to maintain payment plan integrity.
+    """
+    if doc.doctype != "Payment Entry":
+        return
+
+    for ref in doc.get("references", []):
+        if ref.reference_doctype == "Sales Invoice":
+            finance_app = frappe.db.get_value(
+                "Sales Invoice",
+                ref.reference_name,
+                "custom_finance_application"
+            )
+
+            if finance_app:
+                if not doc.custom_is_finance_payment:
+                    frappe.throw(
+                        _(
+                            "Cannot create Payment Entry directly against financed Sales Invoice {0}. "
+                            "This invoice is linked to Finance Application {1}.<br><br>"
+                            "Please follow the proper workflow:<br>"
+                            "1. Go to the Finance Application {1}<br>"
+                            "2. Create payment from there or use the payment plan workflow"
+                        ).format(
+                            frappe.bold(ref.reference_name),
+                            frappe.bold(finance_app)
+                        ),
+                        title=_("Financed Sales Invoice - Direct Payment Not Allowed")
+                    )
+
+                fa_name = frappe.get_value(
+                    "Sales Invoice", ref.reference_name, "custom_finance_application"
+                )
+                if not fa_name:
+                    frappe.throw(
+                        _(
+                            "Payment Entry with 'Finance Payment' enabled must reference "
+                            "a financed Sales Invoice with a valid Finance Application link."
+                        ),
+                        title=_("Invalid Finance Payment Configuration")
+                    )

--- a/financed_sales/hooks.py
+++ b/financed_sales/hooks.py
@@ -40,6 +40,7 @@ doc_events = {
 		"on_update_after_submit": [ "financed_sales.financed_sales.create_docs_on_approval.main"],
 	},
 	"Payment Entry": {
+		"validate": ["financed_sales.financed_sales.validate_payment_entry.validate_payment_entry_references"],
 		"on_submit": ["financed_sales.financed_sales.update_payments.main"],
 	},
 	"Sales Invoice": {


### PR DESCRIPTION
## Summary
This PR adds support for creating payments with a custom (past) date and correctly calculating penalties based on that date.

### Feature: Custom Payment Date
- Allows registering payments with a past date when a client paid on time but the payment wasn't recorded immediately
- Validates that payment dates are chronological (can't be before the last recorded payment)
- Creates Journal Entries with the correct past date for penalty payments

### Bug Fix: Penalty Calculation for Past-Date Payments
- Updates in-memory installment objects alongside DB updates so `analyze_payment_allocation()` sees correct penalty values
- Reloads payment plan after Payment Entry submission so `calculate_overdue_penalties()` sees updated `paid_amount` from the `update_payments()` hook

## Commits
- `7f961ad` fix(payment): prevent direct payments against financed Sales Invoices
- `e772314` feat(payment): add custom payment date with chronological validation
- `fbbd1d2` feat(payment): recalculate penalty based on payment date
- `cc2d2ab` refactor(payment): use existing calculate_overdue_penalties with date param
- `63e08ca` test(payment): add tests for custom payment date feature
- `1a5b4ee` test(payment): rewrite test to verify past date penalty calculation
- `91acb3c` fix(payment): correct penalty calculation for past-date payments

## Problem Solved
When a client paid on time but the payment wasn't registered immediately, penalties would accumulate. Creating a payment with a past date would not correctly calculate penalties as of that past date - penalties remained at today's values.