### PR TITLE
Fix over-delivery error when approving financed sales

### DIFF
--- a/financed_sales/financed_sales/create_docs_on_approval.py
+++ b/financed_sales/financed_sales/create_docs_on_approval.py
@@ -74,6 +74,7 @@ def create_credit_inv(doc, submit = True):
 	invoice.due_date = doc.installments[-1].due_date
 	invoice.allocate_advances_automatically = 1
 	invoice.only_include_allocated_payments = 1
+	invoice.update_stock = 0
 
 	# Calculate financed total from existing financed items
 	financed_total = 0

--- a/financed_sales/financed_sales/factories/payment_plan_factory.py
+++ b/financed_sales/financed_sales/factories/payment_plan_factory.py
@@ -177,6 +177,7 @@ def _create_test_credit_invoice(finance_app):
         'due_date': frappe.utils.add_days(frappe.utils.today(), 30),
         'custom_is_credit_invoice': True,
         'custom_finance_application': finance_app.name,
+        'update_stock': 0,
         'items': [{
             'doctype': 'Sales Invoice Item',
             'item_code': 'Test Credit Item',
@@ -478,6 +479,7 @@ def _create_test_credit_invoice_fixed(finance_app, company):
         'due_date': frappe.utils.add_days(frappe.utils.today(), 30),
         'custom_is_credit_invoice': False,
         'custom_finance_application': finance_app.name,
+        'update_stock': 0,
         'items': [{
             'doctype': 'Sales Invoice Item',
             'item_code': 'Test Credit Item',


### PR DESCRIPTION
## Summary
- Set `update_stock = 0` when creating Sales Invoice during Finance Application approval
- Prevents duplicate stock updates when Sales Order already has Delivery Note
- Fixes over-delivery validation error for financed sales with delivery notes

## Problem
When 'Update Stock' field defaults to 1 for Sales Invoice, approving a financed sales application causes an error if the associated sales orders have delivery notes.

Error:
```
This document is over limit by Qty 1.0 for item 22001. Are you making another Sales Invoice against the same Sales Order Item?
```

## Solution
Set `update_stock` to 0 when creating Sales Invoice during approval workflow to prevent duplicate stock updates.

## Testing
- Applied fix to main approval workflow
- Applied fix to test factory functions for consistency

Closes #29